### PR TITLE
adjust hyara to work in BN plugin manager, PySide 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hyara
 
-![Version](https://img.shields.io/badge/version-2.0-blue.svg?cacheSeconds=2592000)
+![Version](https://img.shields.io/badge/version-2.2-blue.svg?cacheSeconds=2592000)
 
-<img src="images/Hyara.gif" width="100%">
+![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara.gif?raw=true)
 
 > Hyara is plugin that provides convenience when writing yararule.
 > 
@@ -20,11 +20,14 @@
 - If you double-click the table, you can clear the rule.
 - `Export Yara Rule`
   - Exports the previously created yara rules.
-<img src="images/Hyara_1.png" width="100%">
+
+![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara_1.png?raw=true)
+
 
 - `Right Click`
   - You can select either start address or end address. (IDA Pro, Cutter)
-<img src="images/Hyara_7.png" width="100%">
+
+![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara_7.png?raw=true)
   
 - `Comment Option`
   - Annotates the instructions next to the condition rule(s).
@@ -33,21 +36,22 @@
 - `String option`
   - This option extracts strings within the range specified.
 
-<img src="images/Hyara_3.png" width="100%">
-<img src="images/cutter_1.png" width="100%">
+![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara_3.png?raw=true)
+![](https://github.com/hyuunnn/Hyara/blob/master/images/cutter_1.png?raw=true)
 
 ## Installation
 
 ### IDA Pro & BinaryNinja
 
+- IDA Pro
 ```bash
 pip install -r requirements.txt
 ```
-- IDA Pro
   - copy ``Hyara_IDA.py and hyara_lib folder`` to $ida_dir/plugins
   - Activate via Edit -> Plugins -> Hyara (or CTRL+SHIFT+Y)
+
 - BinaryNinja
-  - copy ``Hyara_BinaryNinja.py and hyara_lib folder`` to BinaryNinja Plugin directory
+  - Just use the plugin manager!
   - Activate via View -> Show Hyara
 
 ### Cutter
@@ -61,7 +65,7 @@ copy ``__init__.py, Hyara_Cutter.py and hyara_lib folder`` to $cutter_dir/plugin
 
 - Linux
 
-<img src="images/cutter_install__1.png" width="100%">
+![](https://github.com/hyuunnn/Hyara/blob/master/images/cutter_install__1.png?raw=true)
 
 ```bash
 cp -r /tmp/.mount_Cutter5o3a5G/usr /root
@@ -73,7 +77,7 @@ copy ``__init__.py, Hyara_Cutter.py and hyara_lib folder`` to /root/.local/share
 
 Activate via Windows -> Plugins -> Hyara
 
-<img src="images/cutter__0.png" width="100%">
+![](https://github.com/hyuunnn/Hyara/blob/master/images/cutter__0.png?raw=true)
 
 ## Features
 
@@ -81,13 +85,13 @@ Activate via Windows -> Plugins -> Hyara
 - Supports BinaryNinja, Cutter, and IDA
 - YaraChecker
   - Tests the yararule on the fly
-  - <img src="images/Hyara_4.png" width="100%">
+  - ![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara_4.png?raw=true)
 - YaraDetector
   - Shows which part is detected in the sample loaded to disassembler, and when "Address" is clicked, it moves to the corresponding address on the disassembler view.
-  - <img src="images/Hyara_5.png" width="100%">
+  - ![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara_5.png?raw=true)
 - YaraIcon
   - Creates yara rules for icon resources embedded in the PE.
-  - <img src="images/Hyara_6.png" width="100%">
+  - ![](https://github.com/hyuunnn/Hyara/blob/master/images/Hyara_6.png?raw=true)
 
 ## Author
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,13 @@
-from . import Hyara_Cutter
+import imp
+try:
+    imp.find_module('cutter')
+    cutter_found = True
+except ImportError:
+    cutter_found = False
 
+if cutter_found:
+    import cutter
+    from . import Hyara_Cutter
 
-def create_cutter_plugin():
-    return Hyara_Cutter.HyaraPlugin()
+    def create_cutter_plugin():
+        return Hyara_Cutter.HyaraPlugin()

--- a/hyara_lib/integration/bn_hyara/__init__.py
+++ b/hyara_lib/integration/bn_hyara/__init__.py
@@ -1,8 +1,8 @@
-from hyara_lib.integration.binaryninja_api import HyaraBinaryNinja
+from .binaryninja_api import HyaraBinaryNinja
 
-import PySide2.QtWidgets as QtWidgets
-from PySide2.QtCore import Qt
 from binaryninjaui import DockHandler, DockContextHandler, UIActionHandler
+import PySide6.QtWidgets as QtWidgets
+from PySide6.QtCore import Qt
 
 
 class HyaraDockWidget(QtWidgets.QWidget, DockContextHandler):

--- a/hyara_lib/integration/bn_hyara/binaryninja_api.py
+++ b/hyara_lib/integration/bn_hyara/binaryninja_api.py
@@ -1,4 +1,4 @@
-from ..ui.settings import HyaraGUI
+from ...ui.settings import HyaraGUI
 import pefile
 import binascii
 

--- a/hyara_lib/integration/bn_hyara/plugin.json
+++ b/hyara_lib/integration/bn_hyara/plugin.json
@@ -1,0 +1,31 @@
+{
+    "pluginmetadataversion": 2,
+    "name": "Hyara",
+    "type": [
+        "ui"
+    ],
+    "api": [
+        "python2",
+        "python3"
+    ],
+    "description": "YARA rule making tool for Binary Ninja, Cutter, and IDA",
+    "license": {
+        "name": "MIT",
+        "text": "Copyright (c) 2018 Hyun Yi\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+    },
+    "platforms": [
+        "Darwin",
+        "Linux",
+        "Windows"
+    ],
+    "installinstructions": {
+        "Darwin": "",
+        "Linux": "",
+        "Windows": ""
+    },
+    "dependencies": {
+    },
+    "version": "2.2",
+    "author": "Hyun Yi",
+    "minimumbinaryninjaversion": 3469
+}

--- a/hyara_lib/plugins/yara_checker.py
+++ b/hyara_lib/plugins/yara_checker.py
@@ -5,7 +5,10 @@ if "idaapi" in modules:
     from PyQt5 import QtWidgets
 else:
     # We are running inside Cutter or Binary Ninja
-    import PySide2.QtWidgets as QtWidgets
+    try:
+        import PySide2.QtWidgets as QtWidgets
+    except:
+        import PySide6.QtWidgets as QtWidgets
 
 import os.path
 import yara

--- a/hyara_lib/plugins/yara_detector.py
+++ b/hyara_lib/plugins/yara_detector.py
@@ -5,7 +5,10 @@ if "idaapi" in modules:
     from PyQt5 import QtWidgets
 else:
     # We are running inside Cutter or Binary Ninja
-    import PySide2.QtWidgets as QtWidgets
+    try:
+        import PySide2.QtWidgets as QtWidgets
+    except:
+        import PySide6.QtWidgets as QtWidgets
 
 import os.path
 import yara

--- a/hyara_lib/plugins/yara_icon.py
+++ b/hyara_lib/plugins/yara_icon.py
@@ -5,9 +5,14 @@ if "idaapi" in modules:
     from PyQt5 import QtWidgets, QtCore, QtGui
 else:
     # We are running inside Cutter or Binary Ninja
-    import PySide2.QtWidgets as QtWidgets
-    import PySide2.QtCore as QtCore
-    import PySide2.QtGui as QtGui
+    try:
+        import PySide2.QtWidgets as QtWidgets
+        import PySide2.QtCore as QtCore
+        import PySide2.QtGui as QtGui
+    except:
+        import PySide6.QtWidgets as QtWidgets
+        import PySide6.QtCore as QtCore
+        import PySide6.QtGui as QtGui
 
 from PIL import Image
 from PIL.ImageQt import ImageQt

--- a/hyara_lib/ui/settings.py
+++ b/hyara_lib/ui/settings.py
@@ -5,7 +5,10 @@ if "idaapi" in modules:
     from PyQt5 import QtWidgets
 else:
     # We are running inside Cutter or Binary Ninja
-    import PySide2.QtWidgets as QtWidgets
+    try:
+        import PySide2.QtWidgets as QtWidgets
+    except:
+        import PySide6.QtWidgets as QtWidgets
 
 from abc import ABCMeta, abstractmethod
 from ..plugins import yara_checker, yara_detector, yara_icon


### PR DESCRIPTION
Only thing left is to create the tag and release (I've already updated the version in the readme and the new `plugin.json` required for the plugin manager. This PR:

- Adds PySide6 support for BN 3.0 and newer (which uses Qt6 and PySide6)
- Update readme to work better in the plugin manager view (there's still a few visual quirks I might fix later but this is good enough for now). Looks visually identical in the GH viewer from what I can tell.
- Change `__init__.py` to not auto-load cutter if cutter is not available. 
- Added new plugin.json file for BN plugin manager. Feel free to change anything in there, works pretty well though so far!
- Mostly just moved a few files around and changed imports accordingly

Oh, if you happen to ever remake the introduction GIF it would be great if it started on BN first because our plugin manager doesn't support animated gifs and it's a bit awkward that the first frame shows IDA. 🤣 Of course, Lighthouse has the same issue. 

Once you accept the PR and create the release, I'll add it to the official plugin manager and it will look like this for everyone!

![Screen Shot 2022-06-14 at 7 48 29 PM](https://user-images.githubusercontent.com/140215/173707649-c3dd824f-9f36-4f87-accc-742cf353d8f8.png)

A few other long-term notes while I'm at it:

- There's a newer more reliable method to get the current `bv` instead of the DockWidget method, I'll try to remember to PR that later.
- In the future, dock-widgets will be deprecated and should eventually be replaced with `global area`, `panel`, or `view` widgets, but that is also a more substantial change for another time.

This PR resolves #9.